### PR TITLE
Exception handling

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -16,6 +16,6 @@ class Controller extends HttpController
     {
         return view('welcome', [
             'version' => '2.x-alpha',
-        ])->statusCode(404);
+        ]);
     }
 }

--- a/core/Contracts/Application/Exceptions/ExceptionContract.php
+++ b/core/Contracts/Application/Exceptions/ExceptionContract.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Uwi\Contracts\Application\Exceptions;
+
+use Uwi\Contracts\Http\Response\ResponsableContract;
+
+interface ExceptionContract extends ResponsableContract
+{
+    /**
+     * Make response from some other kind of Exceptions.
+     *
+     * @param \Throwable $e
+     * @return mixed
+     */
+    public static function makeResponse(\Throwable $e): mixed;
+}

--- a/core/Contracts/Database/ConnectionContract.php
+++ b/core/Contracts/Database/ConnectionContract.php
@@ -11,7 +11,7 @@ interface ConnectionContract extends SingletonContract
      *
      * @return integer|null
      */
-    public function lastInsertedId(): ?int;
+    public function lastInsertedId(): int|null;
 
     /**
      * Exec a query.

--- a/core/Contracts/Http/Response/ResponsableContract.php
+++ b/core/Contracts/Http/Response/ResponsableContract.php
@@ -2,6 +2,8 @@
 
 namespace Uwi\Contracts\Http\Response;
 
+use Uwi\Contracts\Http\Request\RequestContract;
+
 interface ResponsableContract
 {
     /**
@@ -10,5 +12,5 @@ interface ResponsableContract
      * @param \Uwi\Contracts\Http\Request\RequestContract $request
      * @return mixed
      */
-    public function toResponse(\Uwi\Contracts\Http\Request\RequestContract $request): mixed;
+    public function toResponse(RequestContract $request): mixed;
 }

--- a/core/Contracts/Http/Response/ResponsableContract.php
+++ b/core/Contracts/Http/Response/ResponsableContract.php
@@ -2,15 +2,13 @@
 
 namespace Uwi\Contracts\Http\Response;
 
-use Uwi\Contracts\Http\Request\RequestContract;
-
 interface ResponsableContract
 {
     /**
-     * Convert object to response.
+     * Convert object to response data.
      *
-     * @param RequestContract $request
+     * @param \Uwi\Contracts\Http\Request\RequestContract $request
      * @return mixed
      */
-    public function toResponse(RequestContract $request): mixed;
+    public function toResponse(\Uwi\Contracts\Http\Request\RequestContract $request): mixed;
 }

--- a/core/Contracts/Http/Routing/RouterContract.php
+++ b/core/Contracts/Http/Routing/RouterContract.php
@@ -19,7 +19,7 @@ interface RouterContract extends SingletonContract
      *
      * @return \Uwi\Contracts\Http\Routing\RouteContract
      * 
-     * @throws Exception
+     * @throws \Uwi\Contracts\Application\Exceptions\ExceptionContract
      */
     public function current(): \Uwi\Contracts\Http\Routing\RouteContract;
 }

--- a/core/Foundation/Application.php
+++ b/core/Foundation/Application.php
@@ -4,8 +4,11 @@ namespace Uwi\Foundation;
 
 use Uwi\Container\Container;
 use Uwi\Contracts\Application\ApplicationContract;
+use Uwi\Contracts\Application\Exceptions\ExceptionContract;
 use Uwi\Contracts\Application\KernelContract;
 use Uwi\Contracts\Application\ServiceLoaderContract;
+use Uwi\Contracts\Http\Response\ResponseContract;
+use Uwi\Foundation\Exceptions\Exception;
 
 class Application extends Container implements ApplicationContract
 {
@@ -132,8 +135,12 @@ class Application extends Container implements ApplicationContract
     public function start(): void
     {
         $this->bootServices();
-        $response = $this->tap([KernelContract::class, 'start']);
-
-        $response->send();
+        try {
+            $this->tap([KernelContract::class, 'start'])->send();
+        } catch (ExceptionContract $e) {
+            $this->tap([$e, 'toResponse'])->send();
+        } catch (\Throwable $e) {
+            Exception::makeResponse($e)->send();
+        }
     }
 }

--- a/core/Foundation/Exceptions/Exception.php
+++ b/core/Foundation/Exceptions/Exception.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Uwi\Foundation\Exceptions;
+
+use Uwi\Contracts\Application\Exceptions\ExceptionContract;
+
+class Exception extends \Exception implements ExceptionContract
+{
+    protected const DEFAULT_STATUS_CODE = 500;
+
+    /**
+     * Instantiate new Exception.
+     *
+     * @param string $message
+     * @param integer $statusCode
+     */
+    public function __construct(
+        string $message = '',
+        protected int $statusCode = self::DEFAULT_STATUS_CODE,
+    ) {
+        $this->message = $message;
+    }
+
+    /**
+     * Convert object to response data.
+     *
+     * @param \Uwi\Contracts\Http\Request\RequestContract $request
+     * @return mixed
+     */
+    public function toResponse(\Uwi\Contracts\Http\Request\RequestContract $request): mixed
+    {
+        return view('errors.500', [
+            'e' => $this,
+        ])->statusCode($this->statusCode);
+    }
+
+    /**
+     * Make response from some other kind of Exceptions.
+     *
+     * @param \Throwable $e
+     * @return mixed
+     */
+    public static function makeResponse(\Throwable $e): mixed
+    {
+        return view('errors.500', [
+            'e' => $e,
+        ])->statusCode(self::DEFAULT_STATUS_CODE);
+    }
+}

--- a/core/Foundation/Exceptions/Exception.php
+++ b/core/Foundation/Exceptions/Exception.php
@@ -3,6 +3,7 @@
 namespace Uwi\Foundation\Exceptions;
 
 use Uwi\Contracts\Application\Exceptions\ExceptionContract;
+use Uwi\Contracts\Http\Request\RequestContract;
 
 class Exception extends \Exception implements ExceptionContract
 {
@@ -27,7 +28,7 @@ class Exception extends \Exception implements ExceptionContract
      * @param \Uwi\Contracts\Http\Request\RequestContract $request
      * @return mixed
      */
-    public function toResponse(\Uwi\Contracts\Http\Request\RequestContract $request): mixed
+    public function toResponse(RequestContract $request): mixed
     {
         return view('errors.500', [
             'e' => $this,

--- a/core/Foundation/Kernel/HttpKernel.php
+++ b/core/Foundation/Kernel/HttpKernel.php
@@ -7,7 +7,6 @@ use Uwi\Contracts\Application\KernelContract;
 use Uwi\Contracts\Http\Response\ResponseContract;
 use Uwi\Contracts\Http\Request\RequestContract;
 use Uwi\Contracts\Http\Routing\RouterContract;
-use Uwi\Services\Http\Response\Facades\Response;
 
 class HttpKernel implements KernelContract
 {
@@ -33,8 +32,8 @@ class HttpKernel implements KernelContract
      */
     public function start(): ResponseContract
     {
-        $controllerResponse = $this->app->tap($this->router->current()->action()) ?? null;
-
-        return Response::make($controllerResponse);
+        return response(
+            $this->app->tap($this->router->current()->action()) ?? null
+        );
     }
 }

--- a/core/Helpers/debug.php
+++ b/core/Helpers/debug.php
@@ -21,7 +21,7 @@ function d(mixed ...$args): void
                 padding: 25px;
                 color: #00cf2d;
                 font-size: .8em;
-                font-family: 'Fira Code';
+                font-family: 'Consolas', sans-serif;
                 white-space: pre-wrap;
                 background: #0d0d0e; }
         </style>
@@ -64,39 +64,46 @@ function dd(mixed ...$args): void
  */
 function ddException(Throwable $e): void
 {
-    $stackTraceDepth = 0;
+    http_response_code(500);
 
-    dd(
-        implode('<br />', array_merge([
-            <<<HTML
-            <br />
-            Internal Server Error
-            Server cannot send a response.
+    echo <<<HTML
+    <!DOCTYPE html>
+    <html lang="en">
 
-            <p>
-            <b>Message:</b> {$e->getMessage()} <br />
-            <b>Exit code:</b> {$e->getCode()} <br />
-            <b>In File:</b> {$e->getFile()} <br />
-            <b>On Line:</b> {$e->getLine()}
-            </p>
-            HTML, '', '', '',
+    <head>
+        <!-- Meta -->
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        
+        <!-- Style -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css">
 
+        <!-- Title -->
+        <title>Exception occured</title>
+    </head>
 
-            'Stack Trace:', '',
+    <body class="bg-light">
+        <div class="container-fluid">
+            <div class="row">
+                <h1 class="m-0 py-4 p-5 bg-dark text-white"><span class="text-danger">Exception:</span> <span class="fs-4">{$e->getMessage()}</span></h1>
 
-        ], array_map(function ($el) use (&$stackTraceDepth) {
-            extract($el);
-            $el = '#' . $stackTraceDepth++ . ' ';
+                <article class="p-5">
+                    <div><b>In File:</b> {$e->getFile()}</div>
+                    <div><b>On Line:</b> {$e->getLine()}</div>
+                    <div><b>Exit Code:</b> {$e->getCode()}</div>
+                </article>
+            </div>
+            <div class="row">
+                <h2 class="m-0 py-4 px-5 bg-secondary text-white">Stack Trace</h2>
 
-            $el .= isset($file, $line) ? "$file($line): " : "[Internal code]: ";
+                <code class="py-4 px-5">
+                    <pre>{$e->getTraceAsString()}</pre>
+                </code>
+            </div>
+        </div>
+    </body>
 
-            $args = isset($args)
-                ? ($args = strlen($args = implode(', ', $args)) > 16 ? '...' : $args)
-                : '';
-
-            $el .= isset($class) ? "$class$type$function($args)" : "$function(...)";
-
-            return $el;
-        }, $e->getTrace())))
-    );
+    </html>
+    HTML;
 }

--- a/core/Services/Calibri/Compiler.php
+++ b/core/Services/Calibri/Compiler.php
@@ -3,6 +3,7 @@
 namespace Uwi\Services\Calibri;
 
 use Uwi\Contracts\Application\ApplicationContract;
+use Uwi\Foundation\Exceptions\Exception;
 use Uwi\Services\Calibri\Contracts\CompilerContract;
 use Uwi\Services\Calibri\Contracts\DirectiveContract;
 use Uwi\Services\Calibri\Directives\ExtendsDirective;
@@ -261,7 +262,11 @@ class Compiler implements CompilerContract
     protected function readNext(): string|false
     {
         if (is_null($this->fileStream)) {
-            $this->fileStream = fopen($this->viewPath, 'r');
+            $this->fileStream = @fopen($this->viewPath, 'r');
+
+            if ($this->fileStream === false) {
+                throw new Exception("No such file for view at [{$this->viewPath}]");
+            }
         }
 
         $line = '';

--- a/core/Services/Calibri/Contracts/ViewContract.php
+++ b/core/Services/Calibri/Contracts/ViewContract.php
@@ -2,7 +2,6 @@
 
 namespace Uwi\Services\Calibri\Contracts;
 
-use Uwi\Contracts\Http\Request\RequestContract;
 use Uwi\Contracts\Http\Response\ResponsableContract;
 
 interface ViewContract extends ResponsableContract
@@ -15,10 +14,10 @@ interface ViewContract extends ResponsableContract
     public function render(): string;
 
     /**
-     * Convert object to response.
+     * Convert object to response data.
      *
-     * @param RequestContract $request
+     * @param \Uwi\Contracts\Http\Request\RequestContract $request
      * @return mixed
      */
-    public function toResponse(RequestContract $request): mixed;
+    public function toResponse(\Uwi\Contracts\Http\Request\RequestContract $request): mixed;
 }

--- a/core/Services/Calibri/Contracts/ViewContract.php
+++ b/core/Services/Calibri/Contracts/ViewContract.php
@@ -2,6 +2,7 @@
 
 namespace Uwi\Services\Calibri\Contracts;
 
+use Uwi\Contracts\Http\Request\RequestContract;
 use Uwi\Contracts\Http\Response\ResponsableContract;
 
 interface ViewContract extends ResponsableContract
@@ -19,5 +20,5 @@ interface ViewContract extends ResponsableContract
      * @param \Uwi\Contracts\Http\Request\RequestContract $request
      * @return mixed
      */
-    public function toResponse(\Uwi\Contracts\Http\Request\RequestContract $request): mixed;
+    public function toResponse(RequestContract $request): mixed;
 }

--- a/core/Services/Calibri/View.php
+++ b/core/Services/Calibri/View.php
@@ -3,6 +3,7 @@
 namespace Uwi\Services\Calibri;
 
 use Uwi\Contracts\Application\ApplicationContract;
+use Uwi\Contracts\Http\Request\RequestContract;
 use Uwi\Contracts\Http\Response\ResponsableContract;
 use Uwi\Services\Calibri\Contracts\CompilerContract;
 use Uwi\Services\Calibri\Contracts\ViewContract;
@@ -76,7 +77,7 @@ class View implements ResponsableContract, ViewContract
      * @param \Uwi\Contracts\Http\Request\RequestContract $request
      * @return mixed
      */
-    public function toResponse(\Uwi\Contracts\Http\Request\RequestContract $request): mixed
+    public function toResponse(RequestContract $request): mixed
     {
         return $this->render();
     }

--- a/core/Services/Calibri/View.php
+++ b/core/Services/Calibri/View.php
@@ -3,7 +3,6 @@
 namespace Uwi\Services\Calibri;
 
 use Uwi\Contracts\Application\ApplicationContract;
-use Uwi\Contracts\Http\Request\RequestContract;
 use Uwi\Contracts\Http\Response\ResponsableContract;
 use Uwi\Services\Calibri\Contracts\CompilerContract;
 use Uwi\Services\Calibri\Contracts\ViewContract;
@@ -72,12 +71,12 @@ class View implements ResponsableContract, ViewContract
     }
 
     /**
-     * Convert object to response.
+     * Convert object to response data.
      *
-     * @param RequestContract $request
+     * @param \Uwi\Contracts\Http\Request\RequestContract $request
      * @return mixed
      */
-    public function toResponse(RequestContract $request): mixed
+    public function toResponse(\Uwi\Contracts\Http\Request\RequestContract $request): mixed
     {
         return $this->render();
     }

--- a/core/Services/Database/Connection.php
+++ b/core/Services/Database/Connection.php
@@ -37,7 +37,7 @@ class Connection implements ConnectionContract
      *
      * @return integer|null
      */
-    public function lastInsertedId(): ?int
+    public function lastInsertedId(): int|null
     {
         return $this->connection->lastInsertId();
     }

--- a/core/Services/Database/Lion/Contracts/QueryContract.php
+++ b/core/Services/Database/Lion/Contracts/QueryContract.php
@@ -38,9 +38,9 @@ interface QueryContract
      * Insert new record into the table.
      *
      * @param array<string, mixed> $attributes
-     * @return ?int
+     * @return int|null
      */
-    public function insert(array $attributes): ?int;
+    public function insert(array $attributes): int|null;
 
     /**
      * Update row by primary key with dirty fields.

--- a/core/Services/Database/Lion/Query/Query.php
+++ b/core/Services/Database/Lion/Query/Query.php
@@ -158,9 +158,9 @@ class Query implements QueryContract
      * Insert new record into the table.
      *
      * @param array<string, mixed> $attributes
-     * @return ?int
+     * @return int|null
      */
-    public function insert(array $attributes): ?int
+    public function insert(array $attributes): int|null
     {
         $this->setType('insert');
         $this->grammarProps = $attributes;

--- a/core/Services/Http/Response/Response.php
+++ b/core/Services/Http/Response/Response.php
@@ -117,6 +117,11 @@ class Response implements ResponseContract
         return $this;
     }
 
+    /**
+     * Retrieve a response data.
+     *
+     * @return mixed
+     */
     protected function getResponseData(): mixed
     {
         return is_subclass_of($this->data, ResponsableContract::class)

--- a/core/Services/Http/Routing/Router.php
+++ b/core/Services/Http/Routing/Router.php
@@ -2,10 +2,12 @@
 
 namespace Uwi\Services\Http\Routing;
 
-use Exception;
+use Uwi\Contracts\Application\ApplicationContract;
+use Uwi\Contracts\Application\Exceptions\ExceptionContract;
 use Uwi\Contracts\Http\Request\RequestContract;
 use Uwi\Contracts\Http\Routing\RouteContract;
 use Uwi\Contracts\Http\Routing\RouterContract;
+use Uwi\Foundation\Exceptions\Exception;
 
 class Router implements RouterContract
 {
@@ -19,9 +21,11 @@ class Router implements RouterContract
     /**
      * Instantiate Router.
      *
+     * @param \Uwi\Contracts\Application\ApplicationContract $app
      * @param \Uwi\Contracts\Http\Request\RequestContract $request
      */
     public function __construct(
+        protected ApplicationContract $app,
         protected RequestContract $request
     ) {
         //
@@ -43,7 +47,7 @@ class Router implements RouterContract
      *
      * @return \Uwi\Contracts\Http\Routing\RouteContract
      * 
-     * @throws Exception
+     * @throws \Uwi\Contracts\Application\Exceptions\ExceptionContract
      */
     public function current(): \Uwi\Contracts\Http\Routing\RouteContract
     {
@@ -53,6 +57,6 @@ class Router implements RouterContract
             }
         }
 
-        throw new Exception("Route [{$this->request->url()}] not found");
+        throw new Exception("Route [{$this->request->url()}] not found", 404);
     }
 }

--- a/views/errors/500.clbr.html
+++ b/views/errors/500.clbr.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <!-- Meta -->
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    
+    <!-- Style -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css">
+
+    <!-- Title -->
+    <title>Exception occured</title>
+</head>
+
+<body class="bg-light">
+    <div class="container-fluid">
+        <div class="row">
+            <h1 class="m-0 py-4 p-5 bg-dark text-white"><span class="text-danger">Exception:</span> <span class="fs-4">{{ $e->getMessage() }}</span></h1>
+
+            <article class="p-5">
+                <div><b>In File:</b> {{ $e->getFile() }}</div>
+                <div><b>On Line:</b> {{ $e->getLine() }}</div>
+                <div><b>Exit Code:</b> {{ $e->getCode() }}</div>
+            </article>
+        </div>
+        <div class="row">
+            <h2 class="m-0 py-4 px-5 bg-secondary text-white">Stack Trace</h2>
+
+            <code class="py-4 px-5">
+                <pre>{{ $e->getTraceAsString() }}</pre>
+            </code>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
# Custom Exceptions and handling them

Exception now handling with pretty page with exception information and stack trace.

## Update others

- PHPDoc and type hinting in some places.
- Calibri compiler for handle fopen when file doesn't exists.
- Router now throws an Uwi Exception with setting 404 status code.
- There are two layer of Exception handling global_exception_handler provided by php and setted to ddException and try catch block with sending an Exception Response. Difference between them is that ddException always sends 500 response code with hardcoded html with exception info meanwhile Exception Response check for status code and will select corresponding view file and set this status code as a response code