### PR TITLE
Bug on Calibri compiler

### DIFF
--- a/core/Services/Calibri/Compiler.php
+++ b/core/Services/Calibri/Compiler.php
@@ -355,12 +355,15 @@ class Compiler implements CompilerContract
 
         // Execute evalInterpolations and escapeDirectiveSymbol
         // only then it's zero recursion depth.
-        if (self::$compilingDepth === 1) {
-            $this->evalInterpolations();
-            $this->escapeDirectiveSymbol();
+        try {
+            if (self::$compilingDepth === 1) {
+                $this->evalInterpolations();
+                $this->escapeDirectiveSymbol();
+            }
+        } finally {
+            // Control the recursion depth.
+            self::$compilingDepth--;
         }
-        // Control the recursion depth.
-        self::$compilingDepth--;
 
         return $this->popContent();
     }


### PR DESCRIPTION
The case when an exception in the interpolation led to the fact that the interpolations did not work on the exceptions page